### PR TITLE
Migrate to AndroidX

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/reactivelivedata/build.gradle
+++ b/reactivelivedata/build.gradle
@@ -33,12 +33,12 @@ android {
 }
 
 dependencies {
-    api 'android.arch.lifecycle:livedata:1.1.1'
+    api 'androidx.lifecycle:lifecycle-livedata:2.0.0'
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'junit:junit:4.12'
-    testImplementation 'android.arch.core:core-testing:1.1.1'
+    testImplementation 'androidx.arch.core:core-testing:2.0.0'
 }
 
 tasks.withType(Javadoc).all {

--- a/reactivelivedata/src/main/java/com/github/musichin/reactivelivedata/ReactiveLiveData.kt
+++ b/reactivelivedata/src/main/java/com/github/musichin/reactivelivedata/ReactiveLiveData.kt
@@ -1,13 +1,13 @@
 package com.github.musichin.reactivelivedata
 
-import android.arch.core.util.Function
-import android.arch.lifecycle.LifecycleOwner
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MediatorLiveData
-import android.arch.lifecycle.MutableLiveData
-import android.arch.lifecycle.Observer
-import android.arch.lifecycle.Transformations
-import android.support.annotation.MainThread
+import androidx.arch.core.util.Function
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import androidx.lifecycle.Transformations
+import androidx.annotation.MainThread
 
 class ReactiveLiveData<T : Any?>(private val source: LiveData<T>) {
     companion object {

--- a/reactivelivedata/src/test/java/com/github/musichin/reactivelivedata/ReactiveLiveDataJavaTest.java
+++ b/reactivelivedata/src/test/java/com/github/musichin/reactivelivedata/ReactiveLiveDataJavaTest.java
@@ -1,7 +1,7 @@
 package com.github.musichin.reactivelivedata;
 
-import android.arch.core.executor.testing.InstantTaskExecutorRule;
-import android.arch.lifecycle.LiveData;
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.LiveData;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/reactivelivedata/src/test/java/com/github/musichin/reactivelivedata/ReactiveLiveDataTest.kt
+++ b/reactivelivedata/src/test/java/com/github/musichin/reactivelivedata/ReactiveLiveDataTest.kt
@@ -1,8 +1,8 @@
 package com.github.musichin.reactivelivedata
 
-import android.arch.core.executor.testing.InstantTaskExecutorRule
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MutableLiveData
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull

--- a/reactivelivedata/src/test/java/com/github/musichin/reactivelivedata/TestObserver.kt
+++ b/reactivelivedata/src/test/java/com/github/musichin/reactivelivedata/TestObserver.kt
@@ -1,6 +1,6 @@
 package com.github.musichin.reactivelivedata
 
-import android.arch.lifecycle.Observer
+import androidx.lifecycle.Observer
 import org.junit.Assert
 
 class TestObserver<T> : Observer<T?> {


### PR DESCRIPTION
Migrated to AndroidX.
I use this library in my project and I'm now migrating it to androidx.
Jetifier did well when I use library that depends on support library. But somehow, this library couldn't go well with jetifier.
I think this might because that this library contains many extension functions.